### PR TITLE
Add support for EDITOR environment variable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,13 @@ fn main() {
         print_usage();
         exit(0);
     }
+    if let Some(exe) = env::var_os("EDITOR") {
+        if let Some(exe) = exe.to_str() {
+            config.editor_executable = exe.to_owned();
+        } else {
+            die!("Environment EDITOR configuration non-unicode and can't be used.");
+        }
+    }
     if let Some(x) = &args.set_editor_executable {
         config.editor_executable = x.to_owned();
         confy::store("brnt", &config)


### PR DESCRIPTION
This configuration will overwrite the default one while still being
overwritten by an explicit command line argument. This handling matches
the rules found in other programs such as git etc.

As noted [in this comment](https://www.reddit.com/r/rust/comments/ka5ec8/brnt_i_made_a_filerenaming_tool_in_rust_which_i/gf9274q/) similar projects also use this environment variable.

You're missing an explicit license but I'm okay with donating this code under 
any open source one, regard it as being in public domain as much as 
possible. If you have any trouble choosing one, I have some experience.

<!--  If you don't have any experience choosing one, for small utilities 
such as these I prefer using Apache-2.0 (not copy left) or Mozilla Public 
License (MPL-2.0; copy left within this project) or GPL-3.0 (copy left for 
anything that uses its source). All of them are okay for many people to freely
contribute to. -->
